### PR TITLE
Add order and product domain models

### DIFF
--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,1 +1,3 @@
+pub mod order;
+pub mod product;
 pub mod template;

--- a/src/domain/order.rs
+++ b/src/domain/order.rs
@@ -130,6 +130,12 @@ pub struct UpdateOrder {
     pub updated_at: NaiveDateTime,
 }
 
+impl Default for UpdateOrder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl UpdateOrder {
     /// Create a new patch object with no changes applied yet.
     pub fn new() -> Self {

--- a/src/domain/order.rs
+++ b/src/domain/order.rs
@@ -1,0 +1,235 @@
+use chrono::NaiveDateTime;
+use pushkind_common::pagination::Pagination;
+use serde::{Deserialize, Serialize};
+
+/// Possible lifecycle states for an order managed by a hub.
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum OrderStatus {
+    /// Order has been created but not yet submitted for processing.
+    Draft,
+    /// Order has been submitted and awaits processing.
+    Pending,
+    /// Order is currently being fulfilled.
+    Processing,
+    /// Order has been fulfilled and is considered complete.
+    Completed,
+    /// Order has been cancelled and should not be processed further.
+    Cancelled,
+}
+
+impl Default for OrderStatus {
+    fn default() -> Self {
+        Self::Draft
+    }
+}
+
+/// Domain representation of an order belonging to a hub.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Order {
+    /// Unique identifier of the order.
+    pub id: i32,
+    /// Owning hub identifier.
+    pub hub_id: i32,
+    /// Optional reference to the customer placing the order.
+    pub customer_id: Option<i32>,
+    /// External human-friendly reference for the order.
+    pub reference: Option<String>,
+    /// Current lifecycle status of the order.
+    pub status: OrderStatus,
+    /// Optional notes supplied by the operator.
+    pub notes: Option<String>,
+    /// Total amount represented in the smallest currency unit (for example cents).
+    pub total_cents: i64,
+    /// ISO 4217 currency code used for the order total.
+    pub currency: String,
+    /// Timestamp for when the order record was created.
+    pub created_at: NaiveDateTime,
+    /// Timestamp for the last update to the order record.
+    pub updated_at: NaiveDateTime,
+}
+
+/// Payload required to insert a new order for a hub.
+#[derive(Debug, Clone)]
+pub struct NewOrder {
+    /// Owning hub identifier.
+    pub hub_id: i32,
+    /// Optional reference to the customer placing the order.
+    pub customer_id: Option<i32>,
+    /// External human-friendly reference for the order.
+    pub reference: Option<String>,
+    /// Optional notes supplied by the operator.
+    pub notes: Option<String>,
+    /// Total amount represented in the smallest currency unit (for example cents).
+    pub total_cents: i64,
+    /// ISO 4217 currency code used for the order total.
+    pub currency: String,
+    /// Current lifecycle status of the order.
+    pub status: OrderStatus,
+    /// Timestamp captured when the order payload was created.
+    pub updated_at: NaiveDateTime,
+}
+
+impl NewOrder {
+    /// Build a new order payload with the supplied details and current timestamp.
+    pub fn new(hub_id: i32, total_cents: i64, currency: impl Into<String>) -> Self {
+        let now = chrono::Local::now().naive_utc();
+        Self {
+            hub_id,
+            customer_id: None,
+            reference: None,
+            notes: None,
+            total_cents,
+            currency: currency.into(),
+            status: OrderStatus::default(),
+            updated_at: now,
+        }
+    }
+
+    /// Attach a customer identifier to the order payload.
+    pub fn with_customer_id(mut self, customer_id: i32) -> Self {
+        self.customer_id = Some(customer_id);
+        self
+    }
+
+    /// Attach an external reference identifier to the order payload.
+    pub fn with_reference(mut self, reference: impl Into<String>) -> Self {
+        self.reference = Some(reference.into());
+        self
+    }
+
+    /// Attach operator notes to the order payload.
+    pub fn with_notes(mut self, notes: impl Into<String>) -> Self {
+        self.notes = Some(notes.into());
+        self
+    }
+
+    /// Override the default status for the new order.
+    pub fn with_status(mut self, status: OrderStatus) -> Self {
+        self.status = status;
+        self
+    }
+}
+
+/// Patch data applied when updating an existing order.
+#[derive(Debug, Clone)]
+pub struct UpdateOrder {
+    /// Optional status update.
+    pub status: Option<OrderStatus>,
+    /// Optional notes update.
+    pub notes: Option<Option<String>>,
+    /// Optional total amount update.
+    pub total_cents: Option<i64>,
+    /// Optional currency update.
+    pub currency: Option<String>,
+    /// Optional customer reference update.
+    pub customer_id: Option<Option<i32>>,
+    /// Optional external reference update.
+    pub reference: Option<Option<String>>,
+    /// Timestamp captured when the patch was created.
+    pub updated_at: NaiveDateTime,
+}
+
+impl UpdateOrder {
+    /// Create a new patch object with no changes applied yet.
+    pub fn new() -> Self {
+        let now = chrono::Local::now().naive_utc();
+        Self {
+            status: None,
+            notes: None,
+            total_cents: None,
+            currency: None,
+            customer_id: None,
+            reference: None,
+            updated_at: now,
+        }
+    }
+
+    /// Update the order status.
+    pub fn status(mut self, status: OrderStatus) -> Self {
+        self.status = Some(status);
+        self
+    }
+
+    /// Update the order notes, using `None` to clear an existing value.
+    pub fn notes(mut self, notes: Option<impl Into<String>>) -> Self {
+        self.notes = Some(notes.map(|value| value.into()));
+        self
+    }
+
+    /// Update the total amount of the order.
+    pub fn total_cents(mut self, total_cents: i64) -> Self {
+        self.total_cents = Some(total_cents);
+        self
+    }
+
+    /// Update the currency used for the order.
+    pub fn currency(mut self, currency: impl Into<String>) -> Self {
+        self.currency = Some(currency.into());
+        self
+    }
+
+    /// Update the customer associated with the order, using `None` to clear the value.
+    pub fn customer_id(mut self, customer_id: Option<i32>) -> Self {
+        self.customer_id = Some(customer_id);
+        self
+    }
+
+    /// Update the external reference associated with the order.
+    pub fn reference(mut self, reference: Option<impl Into<String>>) -> Self {
+        self.reference = Some(reference.map(|value| value.into()));
+        self
+    }
+}
+
+/// Query definition used to list orders for a hub.
+#[derive(Debug, Clone)]
+pub struct OrderListQuery {
+    /// Owning hub identifier.
+    pub hub_id: i32,
+    /// Optional status filter.
+    pub status: Option<OrderStatus>,
+    /// Optional customer identifier filter.
+    pub customer_id: Option<i32>,
+    /// Optional search term that matches the reference or notes.
+    pub search: Option<String>,
+    /// Optional pagination options applied to the query.
+    pub pagination: Option<Pagination>,
+}
+
+impl OrderListQuery {
+    /// Construct a query that targets all orders belonging to `hub_id`.
+    pub fn new(hub_id: i32) -> Self {
+        Self {
+            hub_id,
+            status: None,
+            customer_id: None,
+            search: None,
+            pagination: None,
+        }
+    }
+
+    /// Filter the results by the provided status.
+    pub fn status(mut self, status: OrderStatus) -> Self {
+        self.status = Some(status);
+        self
+    }
+
+    /// Filter the results by customer identifier.
+    pub fn customer_id(mut self, customer_id: i32) -> Self {
+        self.customer_id = Some(customer_id);
+        self
+    }
+
+    /// Filter the results by a search term applied to notes or reference fields.
+    pub fn search(mut self, term: impl Into<String>) -> Self {
+        self.search = Some(term.into());
+        self
+    }
+
+    /// Apply pagination to the query with the given page number and page size.
+    pub fn paginate(mut self, page: usize, per_page: usize) -> Self {
+        self.pagination = Some(Pagination { page, per_page });
+        self
+    }
+}

--- a/src/domain/product.rs
+++ b/src/domain/product.rs
@@ -98,6 +98,12 @@ pub struct UpdateProduct {
     pub updated_at: NaiveDateTime,
 }
 
+impl Default for UpdateProduct {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl UpdateProduct {
     /// Create a new patch object with no changes applied yet.
     pub fn new() -> Self {

--- a/src/domain/product.rs
+++ b/src/domain/product.rs
@@ -1,0 +1,203 @@
+use chrono::NaiveDateTime;
+use pushkind_common::pagination::Pagination;
+use serde::{Deserialize, Serialize};
+
+/// Domain representation of a product that can be managed by a hub.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Product {
+    /// Unique identifier of the product.
+    pub id: i32,
+    /// Owning hub identifier.
+    pub hub_id: i32,
+    /// Human-readable name of the product.
+    pub name: String,
+    /// Optional stock keeping unit identifier.
+    pub sku: Option<String>,
+    /// Optional longer description shown to users.
+    pub description: Option<String>,
+    /// Price represented in the smallest currency unit (for example cents).
+    pub price_cents: i64,
+    /// ISO 4217 currency code associated with the product price.
+    pub currency: String,
+    /// Flag indicating whether the product has been archived.
+    pub is_archived: bool,
+    /// Timestamp for when the product record was created.
+    pub created_at: NaiveDateTime,
+    /// Timestamp for the last update to the product record.
+    pub updated_at: NaiveDateTime,
+}
+
+/// Payload required to insert a new product for a hub.
+#[derive(Debug, Clone)]
+pub struct NewProduct {
+    /// Owning hub identifier.
+    pub hub_id: i32,
+    /// Human-readable name of the product.
+    pub name: String,
+    /// Optional stock keeping unit identifier.
+    pub sku: Option<String>,
+    /// Optional longer description shown to users.
+    pub description: Option<String>,
+    /// Price represented in the smallest currency unit (for example cents).
+    pub price_cents: i64,
+    /// ISO 4217 currency code associated with the product price.
+    pub currency: String,
+    /// Timestamp captured when the product payload was created.
+    pub updated_at: NaiveDateTime,
+}
+
+impl NewProduct {
+    /// Build a new product payload with the supplied details and current timestamp.
+    pub fn new(
+        hub_id: i32,
+        name: impl Into<String>,
+        price_cents: i64,
+        currency: impl Into<String>,
+    ) -> Self {
+        let now = chrono::Local::now().naive_utc();
+        Self {
+            hub_id,
+            name: name.into(),
+            sku: None,
+            description: None,
+            price_cents,
+            currency: currency.into(),
+            updated_at: now,
+        }
+    }
+
+    /// Attach an SKU identifier to the product payload.
+    pub fn with_sku(mut self, sku: impl Into<String>) -> Self {
+        self.sku = Some(sku.into());
+        self
+    }
+
+    /// Attach a descriptive text to the product payload.
+    pub fn with_description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+}
+
+/// Patch data applied when updating an existing product.
+#[derive(Debug, Clone)]
+pub struct UpdateProduct {
+    /// Optional name update.
+    pub name: Option<String>,
+    /// Optional SKU update.
+    pub sku: Option<Option<String>>,
+    /// Optional description update.
+    pub description: Option<Option<String>>,
+    /// Optional price update in the smallest currency unit.
+    pub price_cents: Option<i64>,
+    /// Optional currency update.
+    pub currency: Option<String>,
+    /// Whether the product should be archived or restored.
+    pub is_archived: Option<bool>,
+    /// Timestamp captured when the patch was created.
+    pub updated_at: NaiveDateTime,
+}
+
+impl UpdateProduct {
+    /// Create a new patch object with no changes applied yet.
+    pub fn new() -> Self {
+        let now = chrono::Local::now().naive_utc();
+        Self {
+            name: None,
+            sku: None,
+            description: None,
+            price_cents: None,
+            currency: None,
+            is_archived: None,
+            updated_at: now,
+        }
+    }
+
+    /// Update the product name.
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.name = Some(name.into());
+        self
+    }
+
+    /// Update the SKU, using `None` to clear an existing value.
+    pub fn sku(mut self, sku: Option<impl Into<String>>) -> Self {
+        self.sku = Some(sku.map(|value| value.into()));
+        self
+    }
+
+    /// Update the product description, using `None` to clear an existing value.
+    pub fn description(mut self, description: Option<impl Into<String>>) -> Self {
+        self.description = Some(description.map(|value| value.into()));
+        self
+    }
+
+    /// Update the product price.
+    pub fn price_cents(mut self, price_cents: i64) -> Self {
+        self.price_cents = Some(price_cents);
+        self
+    }
+
+    /// Update the currency used for the product.
+    pub fn currency(mut self, currency: impl Into<String>) -> Self {
+        self.currency = Some(currency.into());
+        self
+    }
+
+    /// Archive or restore the product.
+    pub fn archived(mut self, is_archived: bool) -> Self {
+        self.is_archived = Some(is_archived);
+        self
+    }
+}
+
+/// Query definition used to list products for a hub.
+#[derive(Debug, Clone)]
+pub struct ProductListQuery {
+    /// Owning hub identifier.
+    pub hub_id: i32,
+    /// Optional name or description search term.
+    pub search: Option<String>,
+    /// Optional exact SKU filter.
+    pub sku: Option<String>,
+    /// Whether archived products should be included in the results.
+    pub include_archived: bool,
+    /// Optional pagination options applied to the query.
+    pub pagination: Option<Pagination>,
+}
+
+impl ProductListQuery {
+    /// Construct a query that targets all products belonging to `hub_id`.
+    pub fn new(hub_id: i32) -> Self {
+        Self {
+            hub_id,
+            search: None,
+            sku: None,
+            include_archived: false,
+            pagination: None,
+        }
+    }
+
+    /// Filter the results by a search term applied to the name or description.
+    pub fn search(mut self, term: impl Into<String>) -> Self {
+        self.search = Some(term.into());
+        self
+    }
+
+    /// Filter the results by an exact SKU match.
+    pub fn sku(mut self, sku: impl Into<String>) -> Self {
+        self.sku = Some(sku.into());
+        self
+    }
+
+    /// Include archived products in the results.
+    pub fn include_archived(mut self) -> Self {
+        self.include_archived = true;
+        self
+    }
+
+    /// Apply pagination to the query with the given page number and page size.
+    pub fn paginate(mut self, page: usize, per_page: usize) -> Self {
+        self.pagination = Some(Pagination { page, per_page });
+        self
+    }
+}


### PR DESCRIPTION
## Summary
- add domain structs for managing products including create, update, and list helpers
- introduce order domain models with status tracking and query builders
- expose the new order and product modules through the domain entry point

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68dd4e310b50832a9dd53492eaae94de